### PR TITLE
Changed the metric used for odf_system_raw_capacity_used_bytes

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -72,7 +72,7 @@
           {
             record: 'odf_system_raw_capacity_used_bytes',
             expr: |||
-              NooBaa_system_capacity
+              NooBaa_total_usage
             ||| % $._config,
             labels: {
               system_vendor: 'Red Hat',


### PR DESCRIPTION
Changed the metric used for odf_system_raw_capacity_used_bytes from NooBaa_system_capacity to NooBaa_total_usage

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2030602

Signed-off-by: liranmauda <liran.mauda@gmail.com>