### PR TITLE
remove the labels from odf_system object and bucket count

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -102,7 +102,7 @@
           {
             record: 'odf_system_bucket_count',
             expr: |||
-              sum by (namespace, job, service) (NooBaa_num_buckets + NooBaa_num_buckets_claims)
+              sum(NooBaa_num_buckets + NooBaa_num_buckets_claims)
             ||| % $._config,
             labels: {
               system_vendor: 'Red Hat',
@@ -112,7 +112,7 @@
           {
             record: 'odf_system_objects_total',
             expr: |||
-              sum by (namespace, job, service) (NooBaa_num_objects + NooBaa_num_objects_buckets_claims)
+              sum(NooBaa_num_objects + NooBaa_num_objects_buckets_claims)
             ||| % $._config,
             labels: {
               system_vendor: 'Red Hat',


### PR DESCRIPTION
This commit removes the labels from,
- odf_system_bucket_count
- odf_system_objects_total